### PR TITLE
Added Where LINQ statement to GetDrives() call

### DIFF
--- a/OldFileCleanupApp/MainWindow.xaml.cs
+++ b/OldFileCleanupApp/MainWindow.xaml.cs
@@ -28,7 +28,7 @@ namespace OldFileCleanup
         }
         public void GetDriveInformations()
         {
-            DriveInfo[] allDrives = DriveInfo.GetDrives();
+            DriveInfo[] allDrives = DriveInfo.GetDrives().Where(x => x.IsReady == true).ToArray();
             drivesComboBox.ItemsSource = allDrives;
             /* -- the following loop can be used in a console application, need to be rebuild for WPF --
             foreach (DriveInfo d in allDrives)


### PR DESCRIPTION
Added Where LINQ statement to GetDrives() call to filter out drives where IsReady == false to avoid XAML binding failures for unready drives (such as CD-ROM drives).